### PR TITLE
Bump to 3.8.19

### DIFF
--- a/Formula/wpscan.rb
+++ b/Formula/wpscan.rb
@@ -19,13 +19,6 @@ class Wpscan < Formula
     uses_from_macos "libffi"
   end
 
-  # Fixes the --no-update commandline option
-  # https://github.com/wpscanteam/wpscan/pull/1455
-  patch do
-    url "https://github.com/mistydemeo/wpscan/commit/eed763944642416cb5245b4e0cd281cb161122b4.patch?full_index=1"
-    sha256 "0f532dfac5526e75b241e06c17127cd9b608f1450d685a696a2a122e5db545eb"
-  end
-
   def install
     inreplace "lib/wpscan.rb", /DB_DIR.*=.*$/, "DB_DIR = Pathname.new('#{var}/wpscan/db')"
     libexec.install Dir["*"]

--- a/Formula/wpscan.rb
+++ b/Formula/wpscan.rb
@@ -1,8 +1,8 @@
 class Wpscan < Formula
   desc "Black box WordPress vulnerability scanner"
   homepage "https://wpscan.com/wordpress-security-scanner"
-  url "https://github.com/wpscanteam/wpscan/archive/v3.8.18.tar.gz"
-  sha256 "50a1d0c0aa5f8fe6d4c23e2ed607cfe4d924eacaecfed6979ceffe55c8a12cd0"
+  url "https://github.com/wpscanteam/wpscan/archive/v3.8.19.tar.gz"
+  sha256 "33ca4df4508cfbbcd5bce5bf3e1ec3f413fae89fd8476f46fd15c6a8ab319d48"
   head "https://github.com/wpscanteam/wpscan.git"
 
   depends_on "pkg-config" => :build

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,25 @@
+BSD 2-Clause License
+
+Copyright (c) 2020-present, WPScan Team
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Reattempt of https://github.com/wpscanteam/homebrew-tap/pull/3, but this time removing broken patch, as I [proposed](https://github.com/wpscanteam/homebrew-tap/commit/daf6adaeb16e7929ca42c2c81a935bd5e4c55cf5#commitcomment-59605705) in a comment.

