### PR TITLE
Fix installation failures with Ruby compatibility

### DIFF
--- a/Formula/wpscan.rb
+++ b/Formula/wpscan.rb
@@ -5,8 +5,10 @@ class Wpscan < Formula
   sha256 "05391a1f36159db8999150576123944aeac0c2dbbd0b7f87a1f063bd5a6f3b06"
   head "https://github.com/wpscanteam/wpscan.git"
 
+  RUBY_FORMULA = "ruby@3.4"
+
   depends_on "pkg-config" => :build
-  depends_on "ruby"
+  depends_on RUBY_FORMULA
 
   uses_from_macos "curl"
   uses_from_macos "unzip"
@@ -30,11 +32,11 @@ class Wpscan < Formula
     system bundle, "install", "--jobs=#{ENV.make_jobs}"
     wpscan = Dir["#{libexec}/ruby/**/bin/wpscan"].last
 
-    ruby_series = Formula["ruby"].version.to_s.split(".")[0..1].join(".")
+    ruby_series = Formula[RUBY_FORMULA].version.to_s.split(".")[0..1].join(".")
     (bin/"wpscan").write <<~EOS
       #!/bin/bash
       GEM_HOME="#{libexec}/ruby/#{ruby_series}.0" BUNDLE_GEMFILE="#{libexec}/Gemfile" \\
-        exec "#{bundle}" exec "#{Formula["ruby"].opt_bin}/ruby" \\
+        exec "#{Formula[RUBY_FORMULA].opt_bin}/ruby" "#{bundle}" exec \\
         "#{wpscan}" "$@"
     EOS
   end


### PR DESCRIPTION
Fixes #11
Fixes wpscanteam/wpscan#1917

## Proposed changes

* Add `RUBY_FORMULA` constant and pin to `ruby@3.4` (maximum tested version for v3.8.28)
* Fix wrapper script to invoke bundle with Homebrew Ruby instead of system Ruby
* Update all Formula references to use the constant for easy future updates

## Why are these changes being made?

Users installing WPScan on macOS get errors when trying to run it:

**Issue 1: Bundle uses system Ruby instead of Homebrew Ruby**
- The wrapper script called bundle directly, triggering its shebang (`#!/usr/bin/env ruby`)
- This used macOS system Ruby 2.6, which couldn't find the bundler version
- **Fix:** Explicitly invoke bundle with Homebrew's Ruby interpreter

**Issue 2: Ruby 4.0 incompatibility**
- Formula used `depends_on "ruby"` which installs Ruby 4.x
- WPScan v3.8.28 only supports Ruby 3.0-3.4 (tested in CI)
- **Fix:** Pin to `ruby@3.4` via `RUBY_FORMULA` constant

**Note:** This is temporary for v3.8.28. When the next release ships, update `RUBY_FORMULA = "ruby@4.0"` or `"ruby"`.

## Testing instructions

```bash
# 1. Uninstall current installation and remove tap
brew uninstall wpscan 2>/dev/null || true
brew untap wpscanteam/tap

# 2. Checkout this PR branch
git clone https://github.com/wpscanteam/homebrew-tap.git
cd homebrew-tap
git checkout fix/macos-installation-ruby-compatibility

# 3. Add your local checkout as the tap
brew tap wpscanteam/tap $(pwd)

# 4. Install from the modified formula
brew install --build-from-source wpscanteam/tap/wpscan

# 5. Verify it works
wpscan --version

# 6. Verify Ruby 3.4 is installed (not 4.0)
cat /opt/homebrew/bin/wpscan | grep ruby@3.4
```

**Expected:**
- Installation succeeds without bundler errors
- `wpscan --version` displays version without errors
- Ruby 3.4.x is installed (not 4.0)
- Wrapper references `/opt/homebrew/opt/ruby@3.4/bin/ruby`