### PR TITLE
Fix Linux compatibility by replacing MacOS.version conditional

### DIFF
--- a/Formula/wpscan.rb
+++ b/Formula/wpscan.rb
@@ -11,15 +11,10 @@ class Wpscan < Formula
   depends_on RUBY_FORMULA
 
   uses_from_macos "curl"
+  uses_from_macos "libffi", since: :big_sur
   uses_from_macos "unzip"
   uses_from_macos "xz" # for liblxma
   uses_from_macos "zlib"
-
-  if MacOS.version < :catalina
-    depends_on "libffi"
-  else
-    uses_from_macos "libffi"
-  end
 
   def install
     inreplace "lib/wpscan.rb", /DB_DIR.*=.*$/, "DB_DIR = Pathname.new('#{var}/wpscan/db')"

--- a/Formula/wpscan.rb
+++ b/Formula/wpscan.rb
@@ -11,7 +11,7 @@ class Wpscan < Formula
   depends_on RUBY_FORMULA
 
   uses_from_macos "curl"
-  uses_from_macos "libffi", since: :big_sur
+  uses_from_macos "libffi", since: :catalina
   uses_from_macos "unzip"
   uses_from_macos "xz" # for liblxma
   uses_from_macos "zlib"


### PR DESCRIPTION
Fixes #7

## Proposed changes

* Replaced `if MacOS.version < :catalina` conditional with `uses_from_macos "libffi", since: :catalina`
* Reordered dependencies alphabetically to satisfy brew audit requirements

## Why are these changes being made?

The original formula used `MacOS.version < :catalina` to determine whether to install libffi as a dependency or use the system version. This was originally reported as a deprecation warning in issue #7, but Homebrew has since removed support for `MacOS` constants on Linux entirely, causing installation failures.

```
Error: uninitialized constant Formulary::FormulaNamespace...::Wpscan::MacOS
```

This prevents installation completely on Linux systems.

**The fix:**
Using `uses_from_macos` with the `since:` parameter is the idiomatic Homebrew way to handle platform-specific dependencies. It:
- Uses system libffi on macOS Catalina and newer (matching the original behavior)
- Automatically installs Homebrew's libffi on older macOS versions (Mojave and earlier)
- Automatically installs Homebrew's libffi on all Linux systems
- Does not reference `MacOS` constants, maintaining cross-platform compatibility

## Testing instructions

**On Linux (Linuxbrew):**

```bash
# 1. Uninstall current installation and remove tap
brew uninstall wpscan 2>/dev/null || true
brew untap wpscanteam/tap

# 2. Checkout this PR branch
git clone https://github.com/wpscanteam/homebrew-tap.git
cd homebrew-tap
git checkout fix/linux-macos-version-warning

# 3. Add your local checkout as the tap
brew tap wpscanteam/tap $(pwd)

# 4. Install from the modified formula
brew install --build-from-source wpscanteam/tap/wpscan

# 5. Verify it works
wpscan --version

# 6. Run any brew command and verify no MacOS warnings appear
brew --version
```

**Expected on Linux:**
- Installation succeeds without `MacOS` constant errors
- `wpscan --version` displays version correctly
- No deprecation warnings about `MacOS.version` on any brew operations

**On macOS:**

```bash
# 1. Uninstall current installation and remove tap
brew uninstall wpscan 2>/dev/null || true
brew untap wpscanteam/tap

# 2. Checkout this PR branch
git clone https://github.com/wpscanteam/homebrew-tap.git
cd homebrew-tap
git checkout fix/linux-macos-version-warning

# 3. Add your local checkout as the tap
brew tap wpscanteam/tap $(pwd)

# 4. Install from the modified formula
brew install --build-from-source wpscanteam/tap/wpscan

# 5. Verify it works
wpscan --version

# 6. Check which libffi is being used
# On Catalina or newer, should use system libffi
# On Mojave or older, should install Homebrew's libffi
brew list --formula | grep libffi
```

**Expected on macOS:**
- Installation succeeds
- `wpscan --version` works correctly
- On Catalina or newer: system libffi is used (libffi not in `brew list`)
- On Mojave or older: Homebrew's libffi is installed


## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor grants Automattic Inc. the unlimited, non-exclusive right to reuse, modify, and relicense the code.